### PR TITLE
Explicitly link std::filesystem libraries

### DIFF
--- a/source/imas/CMakeLists.txt
+++ b/source/imas/CMakeLists.txt
@@ -40,6 +40,7 @@ uda_plugin(
     ${UDA_CLIENT_LIBRARIES}
     ${IMAS_LOW_LEVEL_LIBRARIES}
     ${Boost_LIBRARIES}
+    stdc++fs
   EXTRA_DEFINITIONS
     ${IMAS_DEFINITIONS}
 )


### PR DESCRIPTION
When using GCC<9, compilation fails because the linker cannot find references for `std::filesystem`. In versions 9 and greater, this is linked by default [as mentioned in GCC 9 changelog](https://gcc.gnu.org/gcc-9/changes.html#:~:text=Using%20the%20types%20and%20functions%20in%20%3Cfilesystem%3E%20does%20not%20require%20linking%20with%20%2Dlstdc%2B%2Bfs%20now.).

```
[100%] Linking CXX shared library libimas_plugin.so
CMakeFiles/imas_plugin.dir/imas_plugin.cpp.o: In function `uda::plugins::imas::Plugin::list_files(IdamPluginInterface*)':
imas_plugin.cpp:(.text+0x9bd1): undefined reference to `std::filesystem::is_empty(std::filesystem::__cxx11::path const&)'
imas_plugin.cpp:(.text+0x9f92): undefined reference to `std::filesystem::__cxx11::directory_iterator::operator*() const'
imas_plugin.cpp:(.text+0xa09d): undefined reference to `std::filesystem::__cxx11::directory_iterator::operator++()'
...
```

This PR explicitly links `stdc++fs` in the `imas` plugin, thereby resolving compilation issues.